### PR TITLE
Issue : Soft keyboard doesn't close on unit change from back panel.

### DIFF
--- a/course/07_backdrop/solution_07_backdrop/lib/backdrop.dart
+++ b/course/07_backdrop/solution_07_backdrop/lib/backdrop.dart
@@ -183,6 +183,7 @@ class _BackdropState extends State<Backdrop>
   }
 
   void _toggleBackdropPanelVisibility() {
+    FocusScope.of(context).requestFocus(new FocusNode());
     _controller.fling(
         velocity: _backdropPanelVisible ? -_kFlingVelocity : _kFlingVelocity);
   }


### PR DESCRIPTION
Enter digits in front panel.
Press drawer icon from top left corner and change Unit.
Keyboard not close on changing category.

Issue resolved.